### PR TITLE
Json data type fix Plugin <-> Paring Server

### DIFF
--- a/html-plugin/src/room-media-plugin/component.tsx
+++ b/html-plugin/src/room-media-plugin/component.tsx
@@ -46,7 +46,7 @@ export function RoomMediaPlugin({pluginUuid: uuid}: RoomMediaPluginProps) {
             if (ws.readyState === WebSocket.OPEN) {
                 try {
                     const data = {
-                        pin: inputValue,
+                        pin: Number(inputValue),
                     };
                     ws.send(JSON.stringify(data));
                 } catch (error) {


### PR DESCRIPTION
Hi, nice project. Found a litte bug. The python paring-server expects pin to be an number.